### PR TITLE
Refact/ranking : 랭킹페이지 성능 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,11 +10,24 @@ import Wiki from "./pages/Wiki";
 import Gallery from "./pages/Gallery";
 import Ranking from "./pages/Ranking";
 import "./styles/reset.css";
+import {
+  sortRanking,
+  getDayAndReset,
+  getRankingDocsToArr,
+  saveRankingInBrowser,
+} from "./utils/timerAndRanking";
 
 function App() {
   useEffect(() => {
-    SaveContents();
-    SaveTeam();
+    if (!sessionStorage.getItem("teamList")) {
+      SaveContents();
+      SaveTeam();
+    }
+    getRankingDocsToArr().then(doc => {
+      const sortedData = sortRanking(doc);
+      saveRankingInBrowser(sortedData);
+    });
+    getDayAndReset();
   }, []);
 
   return (

--- a/src/components/Timer/TimerModal.tsx
+++ b/src/components/Timer/TimerModal.tsx
@@ -6,7 +6,13 @@ import Controls from "./TimerControls";
 import Clock from "../../utils/clock";
 import TimeLabels from "./TimeLabels";
 import StudyStatus from "./StudyStatus";
-import {postData} from "../../utils/timerAndRanking";
+import {
+  postData,
+  sortRanking,
+  getRankingDocsToArr,
+  saveRankingInBrowser,
+  RANKING_URL,
+} from "../../utils/timerAndRanking";
 
 function TimerModal(props: TimerModalProps) {
   const {
@@ -106,8 +112,13 @@ function TimerModal(props: TimerModalProps) {
               <button
                 type="button"
                 className="SubmitButton"
-                onClick={() => {
-                  postData(username);
+                onClick={async () => {
+                  await postData(username);
+                  await getRankingDocsToArr().then(doc => {
+                    const sortedData = sortRanking(doc);
+                    saveRankingInBrowser(sortedData);
+                  });
+                  window.location.replace(RANKING_URL);
                 }}
               >
                 Submit

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,22 +1,14 @@
 import React, {useEffect, useState} from "react";
 import "../styles/ranking/rankingList.css";
 import List from "../components/Ranking/List";
-import {
-  sortRanking,
-  getDayAndReset,
-  getDocsToArr,
-  secsToMins,
-} from "../utils/timerAndRanking";
+import {secsToMins} from "../utils/timerAndRanking";
 
 function Ranking() {
   const [data, setData] = useState<any[]>();
 
   useEffect(() => {
-    getDocsToArr().then(doc => {
-      const sortedData = sortRanking(doc);
-      setData(sortedData);
-    });
-    getDayAndReset();
+    const rankingData = JSON.parse(sessionStorage.getItem("ranking") as string);
+    setData(rankingData);
   }, []);
 
   return (
@@ -24,8 +16,12 @@ function Ranking() {
       <div className="RankingInnerContainer">
         <h1 className="RankingTitle"> ✍ 오늘의 스터디 랭킹 ✍ </h1>
         {data?.length !== 0 ? (
-          data?.map((x, index) => (
-            <List num={index + 1} name={x.name} time={secsToMins(x.time)} />
+          data?.map((list, index) => (
+            <List
+              num={index + 1}
+              name={list.name}
+              time={secsToMins(list.time)}
+            />
           ))
         ) : (
           <>아직 기록하신 분이 없어요 ㅜ</>

--- a/src/utils/timerAndRanking.ts
+++ b/src/utils/timerAndRanking.ts
@@ -9,7 +9,7 @@ import {
 import {db} from "./firebaseConfig";
 
 // collection에 있는 데이터 다 가져온 후 배열로 반환
-export async function getDocsToArr() {
+export async function getRankingDocsToArr() {
   const arr: object[] = [];
   const snap = await getDocs(collection(db, "ranking"));
   snap.forEach(a => {
@@ -21,7 +21,7 @@ export async function getDocsToArr() {
 
 // 이름 & 공부시간 firestore에 포스트
 export async function postData(id: string) {
-  const secs = Number(localStorage.getItem("time"));
+  const secs = Number(sessionStorage.getItem("time"));
   await setDoc(doc(db, "ranking", id), {
     name: id,
     time: secs,
@@ -103,6 +103,15 @@ export const calculateStudyTime = (
   return `총 공부 시간 : ${hours}시간 ${minutes}분 ${seconds}초`;
 };
 
+// 시간 세션스토리지에 저장
 export const saveTimeInBrowser = (time: number | null) => {
-  localStorage.setItem("time", String(time));
+  sessionStorage.setItem("time", String(time));
 };
+
+// 랭킹 세션스토리지에 저장
+export const saveRankingInBrowser = (data: object[]) => {
+  sessionStorage.setItem("ranking", JSON.stringify(data));
+};
+
+// 랭킹 URL 상수
+export const RANKING_URL = "https://techschool-wiki.web.app/ranking";


### PR DESCRIPTION
## 작업내용

- 랭킹페이지 성능 개선
<br>

## 주요 변경점

- 데이터 과다 요청 방지를 위해 App.tsx에서 랭킹 데이터 불러오는 것으로 변경 ( 새로고침 시에만 불러오기 )
- 타이머에서 공부시간 제출 시 랭킹 페이지로 리디렉팅
   - 해당 부분에서 데이터 포스팅 후, **한 번 더 최신 데이터를 불러와** 세션스토리지에 저장합니다!
       - 해당 로직을 넣어주지 않으면, 새로고침을 2번 해야 최신데이터가 랭킹페이지 반영되기에 추가했습니다
       - 해당 로직이 종료된 이후 랭킹페이지로 리디렉팅되며 페이지 새로고침이 발생합니다
- 랭킹 관련 브라우저 저장소 세션 스토리지로 통일
<br>

## 유의할 점 (optional)

<br>

## To Reviewers (optional)

-  
